### PR TITLE
WIP: expand multiline input on Mac OS X

### DIFF
--- a/src/uisupport/multilineedit.cpp
+++ b/src/uisupport/multilineedit.cpp
@@ -22,6 +22,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QScrollBar>
+#include <QEvent>
 
 #include "actioncollection.h"
 #include "bufferview.h"
@@ -30,6 +31,8 @@
 #include "tabcompleter.h"
 
 const int leftMargin = 3;
+
+const int MultiLineEdit::_macSizeChangeEvent = QEvent::MacSizeChange;
 
 MultiLineEdit::MultiLineEdit(QWidget *parent)
     : MultiLineEditParent(parent),
@@ -149,8 +152,11 @@ void MultiLineEdit::resizeEvent(QResizeEvent *event)
     QTextEdit::resizeEvent(event);
     updateSizeHint();
     updateScrollBars();
+# ifdef Q_WS_MAC
+    // QCoreApplication::postEvent ( QObject * receiver, QEvent * event )
+    QCoreApplication::postEvent(this, new QEvent((QEvent::Type)_macSizeChangeEvent));
+#endif
 }
-
 
 void MultiLineEdit::updateSizeHint()
 {
@@ -314,6 +320,11 @@ void MultiLineEdit::keyPressEvent(QKeyEvent *event)
             return;
         }
         MultiLineEditParent::keyPressEvent(event);
+
+# ifdef Q_WS_MAC
+    // QCoreApplication::postEvent ( QObject * receiver, QEvent * event )
+    QCoreApplication::postEvent(this, new QEvent((QEvent::Type)_macSizeChangeEvent));
+#endif
         return;
     }
 

--- a/src/uisupport/multilineedit.h
+++ b/src/uisupport/multilineedit.h
@@ -28,6 +28,7 @@
 #  include <KDE/KTextEdit>
 #  define MultiLineEditParent KTextEdit
 #else
+#  include <QEvent>
 #  include <QTextEdit>
 #  define MultiLineEditParent QTextEdit
 #endif
@@ -133,6 +134,8 @@ private:
     void showHistoryEntry();
     void updateScrollBars();
     void updateSizeHint();
+
+    static const int _macSizeChangeEvent;
 };
 
 


### PR DESCRIPTION
various attempts at a fix …

Probably an bug in QComboBox::AdjustToContents on Mac OS X
