### PR TITLE
Fix cmd+Q invalidating the Layout somehow

### DIFF
--- a/src/qtui/mainwin.cpp
+++ b/src/qtui/mainwin.cpp
@@ -172,7 +172,8 @@ MainWin::MainWin(QWidget *parent)
     _titleSetter(this),
     _awayLog(0),
     _layoutLoaded(false),
-    _activeBufferViewIndex(-1)
+    _activeBufferViewIndex(-1),
+    _aboutToQuit(false)
 {
     setAttribute(Qt::WA_DeleteOnClose, false); // we delete the mainwin manually
 
@@ -1496,13 +1497,20 @@ void MainWin::closeEvent(QCloseEvent *event)
     QtUiSettings s;
     QtUiApplication *app = qobject_cast<QtUiApplication *> qApp;
     Q_ASSERT(app);
-    if (!app->isAboutToQuit() && QtUi::haveSystemTray() && s.value("MinimizeOnClose").toBool()) {
+    // On OSX it can happen that the closeEvent occurs twice. (Especially if packaged with Frameworks)
+    // This messes up MainWinState/MainWinHidden save/restore.
+    // It's a bug in Qt: https://bugreports.qt.io/browse/QTBUG-43344
+    if (!_aboutToQuit && !app->isAboutToQuit() && QtUi::haveSystemTray() && s.value("MinimizeOnClose").toBool()) {
         QtUi::hideMainWidget();
         event->ignore();
     }
-    else {
+    else if(!_aboutToQuit) {
+        _aboutToQuit = true;
         event->accept();
         quit();
+    }
+    else {
+        event->ignore();
     }
 }
 

--- a/src/qtui/mainwin.h
+++ b/src/qtui/mainwin.h
@@ -221,5 +221,7 @@ private:
     QHash<int, BufferId> _jumpKeyMap;
     int _activeBufferViewIndex;
 
+    bool _aboutToQuit; //closeEvent can occur multiple times on OSX
+
     friend class QtUi;
 };


### PR DESCRIPTION
On Mac OSX Qt Applications (with Frameworks packaged) receive the CloseEvent twice.
(See https://bugreports.qt.io/browse/QTBUG-43344)
This triggers a bug where Quassels Main-Window stays hidden and all Layout states get reset on next launch.
Workaround by checking if event already received...
